### PR TITLE
Add csxtools dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
   skip: True  # [py<36]
 
@@ -21,6 +21,7 @@ requirements:
     - pip
   run:
     - python
+    - csxtools
     - databroker >=1.0.0b5
     - dill
     - numpy
@@ -33,6 +34,8 @@ requirements:
 test:
   imports:
     - xicam.SAXS
+    - csxtools
+    - csxtools.fastccd
 
 about:
   home: https://github.com/synchrotrons/Xi-cam.SAXS


### PR DESCRIPTION
Otherwise we get this error:
```py
Tue Jan 14 16:42:48 2020 - __init__ - ERROR - 1 -
 Traceback (most recent call last):
   File "/tmp/pilot-jan2020_1/lib/python3.7/site-packages/xicam/plugins/__init__.py", line 493, in __init__
    self.plugin_object = entry_point.load()
   File "/tmp/pilot-jan2020_1/lib/python3.7/site-packages/entrypoints.py", line 82, in load
    mod = import_module(self.module_name)
   File "/tmp/pilot-jan2020_1/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
   File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
   File "<frozen importlib._bootstrap>", line 983, in _find_and_load
   File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
   File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
   File "/tmp/pilot-jan2020_1/lib/python3.7/site-packages/xicam/SAXS/SAXSGUIPlugin.py", line 38, in <module>
    from xicam.SAXS.workflows.xpcs import FourierAutocorrelator, OneTime, TwoTime
   File "/tmp/pilot-jan2020_1/lib/python3.7/site-packages/xicam/SAXS/workflows/xpcs.py", line 12, in <module>
    from ..processing.correction import CSXCorrectImage
   File "/tmp/pilot-jan2020_1/lib/python3.7/site-packages/xicam/SAXS/processing/correction.py", line 1, in <module>
    from csxtools.fastccd import correct_images
 ModuleNotFoundError: No module named 'csxtools'
```